### PR TITLE
adds the ability to format case statements in the linux kernel style

### DIFF
--- a/VHDLFormatter.js
+++ b/VHDLFormatter.js
@@ -258,7 +258,7 @@ class signAlignSettings {
 }
 exports.signAlignSettings = signAlignSettings;
 class BeautifierSettings {
-    constructor(removeComments, removeReport, checkAlias, signAlignSettings, keywordCase, typeNameCase, indentation, newLineSettings, endOfLine, addNewLine) {
+    constructor(removeComments, removeReport, checkAlias, signAlignSettings, keywordCase, typeNameCase, indentation, newLineSettings, endOfLine, addNewLine, caseWhenIndent) {
         this.RemoveComments = removeComments;
         this.RemoveAsserts = removeReport;
         this.CheckAlias = checkAlias;
@@ -269,6 +269,7 @@ class BeautifierSettings {
         this.NewLineSettings = newLineSettings;
         this.EndOfLine = endOfLine;
         this.AddNewLine = addNewLine;
+        this.CaseWhenIndent = caseWhenIndent;
     }
 }
 exports.BeautifierSettings = BeautifierSettings;
@@ -610,7 +611,11 @@ function beautifyCaseBlock(block, result, settings, indent) {
     }
     result.push(new FormattedLine(block.lines[block.cursor], indent));
     block.cursor++;
-    beautify3(block, result, settings, indent + 2);
+    let caseindent = 2;
+    if (settings.CaseWhenIndent == false) {
+        caseindent = 1;
+    }
+    beautify3(block, result, settings, indent + caseindent);
     result[block.cursor].Indent = indent;
 }
 exports.beautifyCaseBlock = beautifyCaseBlock;

--- a/VHDLFormatter.ts
+++ b/VHDLFormatter.ts
@@ -306,9 +306,10 @@ export class BeautifierSettings {
     NewLineSettings: NewLineSettings;
     EndOfLine: string;
     AddNewLine: boolean;
+    CaseWhenIndent: boolean;
     constructor(removeComments: boolean, removeReport: boolean, checkAlias: boolean,
         signAlignSettings: signAlignSettings, keywordCase: string, typeNameCase: string, indentation: string,
-        newLineSettings: NewLineSettings, endOfLine: string, addNewLine: boolean) {
+        newLineSettings: NewLineSettings, endOfLine: string, addNewLine: boolean, caseWhenIndent: boolean) {
         this.RemoveComments = removeComments;
         this.RemoveAsserts = removeReport;
         this.CheckAlias = checkAlias;
@@ -319,6 +320,7 @@ export class BeautifierSettings {
         this.NewLineSettings = newLineSettings;
         this.EndOfLine = endOfLine;
         this.AddNewLine = addNewLine;
+        this.CaseWhenIndent = caseWhenIndent;
     }
 }
 
@@ -690,7 +692,11 @@ export function beautifyCaseBlock(block: CodeBlock, result: (FormattedLine | For
     }
     result.push(new FormattedLine(block.lines[block.cursor], indent));
     block.cursor++;
-    beautify3(block, result, settings, indent + 2);
+    let caseindent = 2;
+    if (settings.CaseWhenIndent == false){
+        caseindent = 1;
+    }
+    beautify3(block, result, settings, indent + caseindent);
     (<FormattedLine>result[block.cursor]).Indent = indent;
 }
 

--- a/index.html
+++ b/index.html
@@ -170,6 +170,10 @@
             <input type="checkbox" id="check_alias">
             <label for="check_alias">Check ALIAS (all long names will be replaced by ALIAS names)</label>
         </div>
+        <div class="checkbox" id="caseWhenIndent_div">
+            <input type="checkbox" id="caseWhenIndent" checked=true>
+            <label for="caseWhenIndent">Indent "whens" in a case statement</label>
+        </div>
         <fieldset id="align_settings_div">
             <legend>Sign Alignment</legend>
             <div id="sign_align_in_div">
@@ -370,6 +374,7 @@
             document.getElementById("keyword_div").elements.namedItem("keywordcase").value = beautifierSettings.KeywordCase;
             document.getElementById("typename_div").elements.namedItem("typenamecase").value = beautifierSettings.TypeNameCase;
             document.getElementById("mix_letter").checked = setting.mixLetter;
+            document.getElementById("caseWhenIndent").checked = beautifierSettings.CaseWhenIndent;
             var eof = beautifierSettings.EndOfLine
             eof = eof.replace(/\r/g, "\\r");
             eof = eof.replace(/\n/g, "\\n");
@@ -409,8 +414,9 @@
             
             var remove_lines = document.getElementById("remove_lines").checked;
             var mix_letter = document.getElementById("mix_letter").checked;
+            var caseWhenIndent = document.getElementById("caseWhenIndent").checked;
             [beautifierSettings, compress] = CreateSettings();
-            vhdlSettings = new VhdlSettings(beautifierSettings, remove_lines, compress, mix_letter);
+            vhdlSettings = new VhdlSettings(beautifierSettings, remove_lines, compress, mix_letter, caseWhenIndent);
             saveSetting(vhdlSettings);
 
             input = beautify(input, beautifierSettings);
@@ -455,6 +461,7 @@
             var keywordcase = document.getElementById("keyword_div").elements.namedItem("keywordcase").value;
             var typenamecase = document.getElementById("typename_div").elements.namedItem("typenamecase").value;            
             var endOfLine = document.getElementById("cust_eol").value;
+            var caseWhenIndent = document.getElementById("caseWhenIndent").checked;
             endOfLine = endOfLine.replace(/\\r/g, "\r");
             endOfLine = endOfLine.replace(/\\n/g, "\n");
             if (compress) {
@@ -500,7 +507,8 @@
                 indentation,
                 newLineSettings,
                 endOfLine,
-                addNewLine);
+                addNewLine,
+                caseWhenIndent);
 
             return [beautifierSettings, compress];
         }

--- a/main.js
+++ b/main.js
@@ -15,6 +15,7 @@ function noFormat() {
         "customise_indentation",
         "compress",
         "mix_letter",
+        "caseWhenIndent",
         "cust_eol",
         "sign_align_mode",
         "keyword",

--- a/main.ts
+++ b/main.ts
@@ -15,6 +15,7 @@ function noFormat() {
         "customise_indentation",
         "compress",
         "mix_letter",
+        "caseWhenIndent",
         "cust_eol",
         "sign_align_mode",
         "keyword",

--- a/tests/VHDLFormatterUnitTests.ts
+++ b/tests/VHDLFormatterUnitTests.ts
@@ -1365,7 +1365,7 @@ function IntegrationTest78() {
 }
 
 function IntegrationTest79() {
-    let settings = new BeautifierSettings(false, false, false, null, "lowercase", "uppercase", null, null, "\r\n", false);
+    let settings = new BeautifierSettings(false, false, false, null, "lowercase", "uppercase", null, null, "\r\n", false, true);
     let input = "case when others;\r\nx : STRING;\r\ny : BIT;";
     let actual = beautify(input, settings);
     assertAndCountTest("uppercase typename and lowercase keyword", input, actual);
@@ -1435,7 +1435,7 @@ function GetDefaultSettings(indentation: string = "    "): BeautifierSettings {
 }
 
 function getDefaultBeautifierSettings(newLineSettings: NewLineSettings, signAlignSettings: signAlignSettings = null, indentation: string = "    "): BeautifierSettings {
-    return new BeautifierSettings(false, false, false, signAlignSettings, "uppercase", "uppercase", indentation, newLineSettings, "\r\n", false);
+    return new BeautifierSettings(false, false, false, signAlignSettings, "uppercase", "uppercase", indentation, newLineSettings, "\r\n", false, true);
 }
 
 


### PR DESCRIPTION
The [Linux kernel style guide](https://www.kernel.org/doc/html/v4.10/process/coding-style.html) suggests that switch/case statements be at a single indentation level.

I've added this as a boolean option for people who follow that style. The default behaviour remains unchanged.