### PR TITLE
Fix formatting initial value block

### DIFF
--- a/VHDLFormatter.ts
+++ b/VHDLFormatter.ts
@@ -858,7 +858,7 @@ export function beautify3(block: CodeBlock, result: (FormattedLine | FormattedLi
             let startIndex = block.cursor;
             beautifySemicolonBlock(block, result, settings, indent);
             if (endsWithBracket && startIndex != block.cursor) {
-                let fl = result[block.end] as FormattedLine;
+                let fl = result[block.cursor] as FormattedLine;
                 if (fl.Line.regexStartsWith(/\);$/)) {
                     fl.Indent--;
                 }


### PR DESCRIPTION
This PR fixes an error when formatting code like the following:

```
constant rom : ROM := (
x"01",
x"02",
x"03"
);

-- some comments
```